### PR TITLE
Added support for custom gateway urls

### DIFF
--- a/src/GoPay.php
+++ b/src/GoPay.php
@@ -8,7 +8,6 @@ use GoPay\Definition\Language;
 
 class GoPay
 {
-
     const JSON = 'application/json';
     const FORM = 'application/x-www-form-urlencoded';
 
@@ -44,10 +43,21 @@ class GoPay
                 true => 'https://gate.gopay.cz/',
                 false => 'https://gw.sandbox.gopay.com/'
         ];
+
+        if ($this->isCustomGatewayUrl()) {
+            return $this->config['gatewayUrl'] . $urlPath;
+        }
+
         return $urls[$this->isProductionMode()] . $urlPath;
     }
 
-    public function isProductionMode() {
+    public function isCustomGatewayUrl()
+    {
+        return array_key_exists('gatewayUrl', $this->config);
+    }
+
+    public function isProductionMode()
+    {
         $productionMode = $this->getConfig('isProductionMode');
         return filter_var($productionMode, FILTER_VALIDATE_BOOLEAN);
     }

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -37,7 +37,7 @@ class OAuth2 implements Auth
     {
         $ids = [
             $this->gopay->getConfig('clientId'),
-            (int) $this->gopay->getConfig('isProductionMode'),
+            $this->gopay->isCustomGatewayUrl() ? 2 : (int) $this->gopay->getConfig('isProductionMode'),
             $this->gopay->getConfig('scope'),
         ];
         return implode('-', $ids);


### PR DESCRIPTION
Přidána podpora pro úpravu OAUTH URL:

Takto vypadá klasický režim režim:
``` php
$gp = Gopay\Api::payments([
    'goid' => $merchant->getGopayGoId(),
    'clientId' => $merchant->getGopayClientId(),
    'clientSecret' => $merchant->getGopayClientSecret(),
    'scope' => TokenScope::ALL,
    'isProductionMode' => true
]);
```

Takto vypadá režim s vlasní URL: 
``` php
$gp = Gopay\Api::payments([
    'goid' => $merchant->getGopayGoId(),
    'clientId' => $merchant->getGopayClientId(),
    'clientSecret' => $merchant->getGopayClientSecret(),
    'scope' => TokenScope::ALL,
    'gatewayUrl' => 'https://nejaka.alfa.beta.url.dev/'
]);
```

Pokud použijeme parametr `gatewayUrl`, tak parametr `isProductionMode` (který ovlivňuje výslednou URL) je nepovinný. 
**Lze používat oba režimy** - buď s parametrem `isProductionMode` nebo s `gatewayUrl`.