### PR TITLE
Change json's type in Response to array

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -8,7 +8,7 @@ class Response
     private $rawBody;
     /** @var int */
     public $statusCode;
-    /** @var object response json */
+    /** @var array response json */
     public $json;
 
     public function __construct($rawBody = '')


### PR DESCRIPTION
Changed the type in annotation for `$json` in the `Response` class from `object` to `array`.