### PR TITLE
Added Config object

### DIFF
--- a/factory.php
+++ b/factory.php
@@ -2,13 +2,9 @@
 
 namespace GoPay;
 
-function payments(array $userConfig, array $userServices = [])
+function payments(array|Config $userConfig, array $userServices = [])
 {
-    $config = $userConfig + [
-        'scope' => Definition\TokenScope::ALL,
-        'language' => Definition\Language::ENGLISH,
-        'timeout' => 30
-    ];
+    $config = Config::parseUserConfig($userConfig);
     $services = $userServices + [
         'cache' => new Token\InMemoryTokenCache,
         'logger' => new Http\Log\NullLogger
@@ -21,17 +17,13 @@ function payments(array $userConfig, array $userServices = [])
 
 /**
  * @deprecated Supercash payments are no longer supported
- * @param array $userConfig
+ * @param array|Config $userConfig
  * @param array $userServices
  * @return PaymentsSupercash
  */
-function paymentsSupercash(array $userConfig, array $userServices = [])
+function paymentsSupercash(array|Config $userConfig, array $userServices = [])
 {
-    $config = $userConfig + [
-                    'scope' => Definition\TokenScope::ALL,
-                    'language' => Definition\Language::ENGLISH,
-                    'timeout' => 30
-            ];
+    $config = Config::parseUserConfig($userConfig);
     $services = $userServices + [
                     'cache' => new Token\InMemoryTokenCache,
                     'logger' => new Http\Log\NullLogger
@@ -45,7 +37,7 @@ function paymentsSupercash(array $userConfig, array $userServices = [])
 /** Symfony container needs class for factory :( */
 class Api
 {
-    public static function payments(array $config, array $services = [])
+    public static function payments(array|Config $config, array $services = [])
     {
         return payments($config, $services);
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace GoPay;
+
+use GoPay\Definition\Language;
+use GoPay\Definition\TokenScope;
+
+class Config
+{
+    /**
+     * @param string|null $clientId {@see https://doc.gopay.com/#access-token}
+     * @param string|null $clientSecret {@see https://doc.gopay.com/#access-token}
+     * @param string|null $goid Default GoPay account used in `createPayment` if `target` is not specified.
+     * @param string|null $gatewayUrl {@see https://help.gopay.com/en/knowledge-base/integration-of-payment-gateway/integration-of-payment-gateway-1/how-do-i-integrate-the-payment-gateway}
+     */
+    public function __construct(
+        public ?string $clientId = null,
+        public ?string $clientSecret = null,
+        public ?string $goid = null,
+        public ?string $gatewayUrl = null,
+    ) {
+    }
+
+    /**
+     * {@see https://doc.gopay.com/#access-token}
+     *
+     * @var string
+     */
+    public string $scope = TokenScope::ALL;
+
+    /**
+     * Language used in `createPayment` if `lang` is not specified + used for
+     * {@see https://doc.gopay.com/#errors localization of errors}.
+     *
+     * @var string
+     */
+    public string $language = Language::ENGLISH;
+
+    /**
+     * Browser timeout in seconds.
+     *
+     * @var int
+     */
+    public int $timeout = 30;
+
+    /**
+     * @param array|Config $userConfig
+     * @param bool $defaultArrayValues
+     * @return array
+     */
+    public static function parseUserConfig(array|Config $userConfig, bool $defaultArrayValues = true): array
+    {
+        if (is_array($userConfig)) {
+            if ($defaultArrayValues) {
+                return $userConfig + [
+                        'scope' => TokenScope::ALL,
+                        'language' => Language::ENGLISH,
+                        'timeout' => 30
+                    ];
+            }
+
+            return $userConfig;
+        } else {
+            return $userConfig->toArray();
+        }
+    }
+
+    /**
+     * @param array $arr
+     * @return Config
+     */
+    public static function fromArray(array $arr): Config
+    {
+        $config = new Config();
+
+        $config->goid = $arr['goid'] ?? null;
+        $config->clientId = $arr['clientId'] ?? null;
+        $config->clientSecret = $arr['clientSecret'] ?? null;
+        $config->gatewayUrl = $arr['gatewayUrl'] ?? null;
+
+        // Properties with default values are set only if their value is provided
+        if (isset($arr['scope'])) {
+            $config->scope = $arr['scope'];
+        }
+        if (isset($arr['language'])) {
+            $config->language = $arr['language'];
+        }
+        if (isset($arr['timeout'])) {
+            $config->timeout = $arr['timeout'];
+        }
+
+        return $config;
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'goid' => $this->goid,
+            'clientId' => $this->clientId,
+            'clientSecret' => $this->clientSecret,
+            'gatewayUrl' => $this->gatewayUrl,
+            'scope' => $this->scope,
+            'language' => $this->language,
+            'timeout' => $this->timeout,
+        ];
+    }
+}

--- a/src/GoPay.php
+++ b/src/GoPay.php
@@ -17,9 +17,9 @@ class GoPay
     private $config;
     private $browser;
 
-    public function __construct(array $config, JsonBrowser $b)
+    public function __construct(array|Config $config, JsonBrowser $b)
     {
-        $this->config = $config;
+        $this->config = Config::parseUserConfig($config, false);
         $this->browser = $b;
     }
 


### PR DESCRIPTION
Hello,

I don't know if this might be needed, but I've __added a Config class to the project that can be passed instead of an array__ when initializing some of the library's objects. This offers several advantages over using an array as a configuration format:

- Users can __immediately see which options are available__ without needing to consult the documentation.
- All __options are type-checked__ (either by the IDE or PHPStan).
- The class __reduces the likelihood of incorrectly typing an option's name__.
- If options are __added or renamed in future updates, static analyzers will flag these changes__.

Originally, I had planned to change the internal config variable used by all classes in this library to the Config class, but this could cause a breaking change due to the [`getConfig($key)` method](https://github.com/gopaycommunity/gopay-php-api/blob/fd171e33520ecc3dc48a3de4712b9f80981cd09d/src/GoPay.php#L26) (since some users might use arrays for more options than this library provides). For now, __this PR doesn't alter any existing behavior__ and simply adds the option of passing configuration values as a Config instance. If you like this change I could alter the code to use this class instead of array in the future (of course this change can still support passing the config as an array).