### PR TITLE
JSON_UNESCAPED_UNICODE

### DIFF
--- a/src/GoPay.php
+++ b/src/GoPay.php
@@ -67,7 +67,7 @@ class GoPay
             if ($contentType === GoPay::FORM) {
                 return http_build_query($data, "", '&');
             }
-            return json_encode($data);
+            return json_encode($data, JSON_UNESCAPED_UNICODE);
         }
         return '';
     }

--- a/tests/integration/CreatePaymentTest.php
+++ b/tests/integration/CreatePaymentTest.php
@@ -64,7 +64,7 @@ class CreatePaymentTest extends TestCase
                         array('name' => 'invoicenumber', 'value' => '2015001003')
                 ],
                 'items' => [
-                        ['name' => 'item01', 'amount' => 2300, 'count' => 1],
+                        ['name' => 'item01 (ěščřžýáíéóúůťďňĚŠČŘŽÝÁÍÉÓÚŮŤĎŇ)[]/\\"\'<>{}&', 'amount' => 2300, 'count' => 1],
                 ],
                 'callback' => [
                         'return_url' => 'https://eshop123.cz/return',


### PR DESCRIPTION
Fix for https://github.com/gopaycommunity/gopay-php-api/issues/69

Prevents 403 api response because of escaped unicode chars inside the request json - by not escaping them

Test adjusted for CZ diacritics and some special characters (we had issue with simple brackets in product names)